### PR TITLE
Naming conventions

### DIFF
--- a/Addons/Manticore_Insignia/NATOFleatInsignia.hpp
+++ b/Addons/Manticore_Insignia/NATOFleatInsignia.hpp
@@ -1,3 +1,4 @@
+// The Recruit Badges look the same so just use the Marine one!
 class Manticore_Insignia_NavyBadge_OR0
 {
 	displayName = "NATO Navy OR-0 [Rct.]";

--- a/Addons/Manticore_Insignia/NATOFleatInsignia.hpp
+++ b/Addons/Manticore_Insignia/NATOFleatInsignia.hpp
@@ -1,6 +1,14 @@
+class Manticore_Insignia_NavyBadge_OR0
+{
+	displayName = "NATO Navy OR-0 [Rct.]";
+	author = "Mattress";
+	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OR0_512x512.paa";
+	textureVehicle = "";
+};
+
 class Manticore_Insignia_NavyBadge_OR1
 {
-	displayName = "NATO Navy OR-1 AR.";
+	displayName = "NATO Navy OR-1 [AR.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OR1_512x512.paa";
 	textureVehicle = "";
@@ -8,7 +16,7 @@ class Manticore_Insignia_NavyBadge_OR1
 
 class Manticore_Insignia_NavyBadge_OR2
 {
-	displayName = "NATO FAA OR-2 AA.";
+	displayName = "NATO Navy OR-2 [AA.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OR2_512x512.paa";
 	textureVehicle = "";
@@ -16,7 +24,7 @@ class Manticore_Insignia_NavyBadge_OR2
 
 class Manticore_Insignia_NavyBadge_OR3
 {
-	displayName = "NATO Navy OR-3 Am.";
+	displayName = "NATO Navy OR-3 [Am.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OR3_512x512.paa";
 	textureVehicle = "";
@@ -24,7 +32,7 @@ class Manticore_Insignia_NavyBadge_OR3
 
 class Manticore_Insignia_NavyBadge_OR4
 {
-	displayName = "NATO Navy OR-4 PO3.";
+	displayName = "NATO Navy OR-4 [PO3.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OR4_512x512.paa";
 	textureVehicle = "";
@@ -32,7 +40,7 @@ class Manticore_Insignia_NavyBadge_OR4
 
 class Manticore_Insignia_NavyBadge_OR5
 {
-	displayName = "NATO Navy OR-5 PO2.";
+	displayName = "NATO Navy OR-5 [PO2.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OR5_512x512.paa";
 	textureVehicle = "";
@@ -40,7 +48,7 @@ class Manticore_Insignia_NavyBadge_OR5
 
 class Manticore_Insignia_NavyBadge_OR6
 {
-	displayName = "NATO Navy OR-6 PO1.";
+	displayName = "NATO Navy OR-6 [PO1.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OR6_512x512.paa";
 	textureVehicle = "";
@@ -48,7 +56,7 @@ class Manticore_Insignia_NavyBadge_OR6
 
 class Manticore_Insignia_NavyBadge_OR7
 {
-	displayName = "NATO Navy OR-7 CPO.";
+	displayName = "NATO Navy OR-7 [CPO.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OR7_512x512.paa";
 	textureVehicle = "";
@@ -56,7 +64,7 @@ class Manticore_Insignia_NavyBadge_OR7
 
 class Manticore_Insignia_NavyBadge_OR8
 {
-	displayName = "NATO Navy OR-8 SCPO.";
+	displayName = "NATO Navy OR-8 [SCPO.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OR8_512x512.paa";
 	textureVehicle = "";
@@ -64,7 +72,7 @@ class Manticore_Insignia_NavyBadge_OR8
 
 class Manticore_Insignia_NavyBadge_OF1_1
 {
-	displayName = "NATO Navy OF-1 Ens.";
+	displayName = "NATO Navy OF-1 [Ens.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OF1-1_512x512.paa";
 	textureVehicle = "";
@@ -72,7 +80,7 @@ class Manticore_Insignia_NavyBadge_OF1_1
 
 class Manticore_Insignia_NavyBadge_OF1_2
 {
-	displayName = "NATO Navy OF-1 LtJG.";
+	displayName = "NATO Navy OF-1 [LtJG.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OF1-2_512x512.paa";
 	textureVehicle = "";
@@ -80,7 +88,7 @@ class Manticore_Insignia_NavyBadge_OF1_2
 
 class Manticore_Insignia_NavyBadge_OF2
 {
-	displayName = "NATO Navy OF-2 Lt.";
+	displayName = "NATO Navy OF-2 [Lt.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OF2_512x512.paa";
 	textureVehicle = "";
@@ -88,7 +96,7 @@ class Manticore_Insignia_NavyBadge_OF2
 
 class Manticore_Insignia_NavyBadge_OF3
 {
-	displayName = "NATO Navy OF-3 LtCdr.";
+	displayName = "NATO Navy OF-3 [LtCdr.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OF3_512x512.paa";
 	textureVehicle = "";
@@ -96,7 +104,7 @@ class Manticore_Insignia_NavyBadge_OF3
 
 class Manticore_Insignia_NavyBadge_OF4
 {
-	displayName = "NATO Navy OF-4 Cdr.";
+	displayName = "NATO Navy OF-4 [Cdr.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\NavyBadgeInsignia_OF4_512x512.paa";
 	textureVehicle = "";

--- a/Addons/Manticore_Insignia/NATOMarineInsignia.hpp
+++ b/Addons/Manticore_Insignia/NATOMarineInsignia.hpp
@@ -1,6 +1,6 @@
 class Manticore_Insignia_MarineBadge_OR0
 {
-	displayName = "NATO Marine OR-0 Rct.";
+	displayName = "NATO Marine OR-0 [Rct.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OR0_512x512.paa";
 	textureVehicle = "";
@@ -8,7 +8,7 @@ class Manticore_Insignia_MarineBadge_OR0
 
 class Manticore_Insignia_MarineBadge_OR1
 {
-	displayName = "NATO Marine OR-1 Pvt.";
+	displayName = "NATO Marine OR-1 [Pvt.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OR1_512x512.paa";
 	textureVehicle = "";
@@ -16,7 +16,7 @@ class Manticore_Insignia_MarineBadge_OR1
 
 class Manticore_Insignia_MarineBadge_OR2
 {
-	displayName = "NATO Marine OR-2 PFC.";
+	displayName = "NATO Marine OR-2 [PFC.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OR2_512x512.paa";
 	textureVehicle = "";
@@ -24,7 +24,7 @@ class Manticore_Insignia_MarineBadge_OR2
 
 class Manticore_Insignia_MarineBadge_OR3
 {
-	displayName = "NATO Marine OR-3 LCpl.";
+	displayName = "NATO Marine OR-3 [LCpl.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OR3_512x512.paa";
 	textureVehicle = "";
@@ -32,7 +32,7 @@ class Manticore_Insignia_MarineBadge_OR3
 
 class Manticore_Insignia_MarineBadge_OR4
 {
-	displayName = "NATO Marine OR-4 Cpl.";
+	displayName = "NATO Marine OR-4 [Cpl.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OR4_512x512.paa";
 	textureVehicle = "";
@@ -40,7 +40,7 @@ class Manticore_Insignia_MarineBadge_OR4
 
 class Manticore_Insignia_MarineBadge_OR5
 {
-	displayName = "NATO Marine OR-5 Sgt.";
+	displayName = "NATO Marine OR-5 [Sgt.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OR5_512x512.paa";
 	textureVehicle = "";
@@ -48,7 +48,7 @@ class Manticore_Insignia_MarineBadge_OR5
 
 class Manticore_Insignia_MarineBadge_OR6
 {
-	displayName = "NATO Marine OR-6 SSgt.";
+	displayName = "NATO Marine OR-6 [SSgt.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OR6_512x512.paa";
 	textureVehicle = "";
@@ -56,7 +56,7 @@ class Manticore_Insignia_MarineBadge_OR6
 
 class Manticore_Insignia_MarineBadge_OR7
 {
-	displayName = "NATO Marine OR-7 GySgt.";
+	displayName = "NATO Marine OR-7 [GySgt.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OR7_512x512.paa";
 	textureVehicle = "";
@@ -64,7 +64,7 @@ class Manticore_Insignia_MarineBadge_OR7
 
 class Manticore_Insignia_MarineBadge_OR8
 {
-	displayName = "NATO Marine OR-8 MSgt.";
+	displayName = "NATO Marine OR-8 [MSgt.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OR8_512x512.paa";
 	textureVehicle = "";
@@ -72,7 +72,7 @@ class Manticore_Insignia_MarineBadge_OR8
 
 class Manticore_Insignia_MarineBadge_OF1_1
 {
-	displayName = "NATO Marine OF-1 2Lt.";
+	displayName = "NATO Marine OF-1 [2Lt.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OF1-1_512x512.paa";
 	textureVehicle = "";
@@ -80,7 +80,7 @@ class Manticore_Insignia_MarineBadge_OF1_1
 
 class Manticore_Insignia_MarineBadge_OF1_2
 {
-	displayName = "NATO Marine OF-1 1Lt.";
+	displayName = "NATO Marine OF-1 [1Lt.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OF1-2_512x512.paa";
 	textureVehicle = "";
@@ -88,7 +88,7 @@ class Manticore_Insignia_MarineBadge_OF1_2
 
 class Manticore_Insignia_MarineBadge_OF2
 {
-	displayName = "NATO Marine OF-2 Cpt.";
+	displayName = "NATO Marine OF-2 [Cpt.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OF2_512x512.paa";
 	textureVehicle = "";
@@ -96,7 +96,7 @@ class Manticore_Insignia_MarineBadge_OF2
 
 class Manticore_Insignia_MarineBadge_OF3
 {
-	displayName = "NATO Marine OF-3 Maj.";
+	displayName = "NATO Marine OF-3 [Maj.]";
 	author = "Mattress";
 	texture = "\Manticore_Insignia\data\MarineBadgeInsignia_OF3_512x512.paa";
 	textureVehicle = "";


### PR DESCRIPTION
Just a start to unify the naming a little more by adding [ ] around the rank names when applyable.
(Doesn't work for Field Badges, but that should be fair enough)
Did the same for the Navy branch, even though it's currently not used. Added the Recuruit as a placeholder and fixed the OR-2 displayName.